### PR TITLE
Adding support for FutureAccessList urn.

### DIFF
--- a/ImagePipeline/FBCore/Common/Util/UriUtil.cs
+++ b/ImagePipeline/FBCore/Common/Util/UriUtil.cs
@@ -48,6 +48,11 @@ namespace FBCore.Common.Util
         public const string FILE_SCHEME = "file";
 
         /// <summary>
+        /// FutureAccessList scheme for URIs.
+        /// </summary>
+        public const string FUTURE_ACCESS_LIST_SCHEME = "urn:future-access-list:";
+
+        /// <summary>
         /// Check if uri represents network resource.
         ///
         /// <param name="uri">uri to check.</param>
@@ -110,6 +115,16 @@ namespace FBCore.Common.Util
         {
             string scheme = GetSchemeOrNull(uri);
             return FILE_SCHEME.Equals(scheme);
+        }
+
+        /// <summary>
+        /// Check if the uri is a FutureAccessList uri.
+        /// </summary>
+        /// <param name="uri">uri to check.</param>
+        public static bool IsFutureAccessListUri(Uri uri)
+        {
+            return (uri == null) ? false : uri.OriginalString.StartsWith(
+                FUTURE_ACCESS_LIST_SCHEME);
         }
 
         /// <summary>

--- a/ImagePipeline/ImagePipeline.Tests/Core/ImagePipelineTests.cs
+++ b/ImagePipeline/ImagePipeline.Tests/Core/ImagePipelineTests.cs
@@ -9,6 +9,7 @@ using ImagePipeline.Request;
 using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
 using System;
 using System.IO;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Windows.Graphics.Imaging;
@@ -1189,6 +1190,32 @@ namespace ImagePipeline.Tests.Core
                 .ConfigureAwait(false);
 
             string token = fa.Add(sourceFile, "test");
+
+            var uri = new Uri($"urn:future-access-list:{ token }");
+            var bitmap = await _imagePipeline.FetchDecodedBitmapImageAsync(
+                ImageRequest.FromUri(uri)).ConfigureAwait(false);
+
+            await DispatcherHelpers.RunOnDispatcherAsync(() =>
+            {
+                Assert.IsTrue(bitmap.PixelWidth != 0);
+                Assert.IsTrue(bitmap.PixelHeight != 0);
+            });
+        }
+
+        /// <summary>
+        /// Tests out fetching a decoded image from future access list.
+        /// The uri is encoded.
+        /// </summary>
+        [TestMethod]
+        public async Task TestFetchFutureAccessListEncodedURI()
+        {
+            // Prepare resource for testing.
+            var fa = StorageApplicationPermissions.FutureAccessList;
+            var sourceFile = await StorageFile.GetFileFromApplicationUriAsync(LOCAL_PNG_URL)
+                .AsTask()
+                .ConfigureAwait(false);
+
+            string token = WebUtility.UrlEncode(fa.Add(sourceFile, "test"));
 
             var uri = new Uri($"urn:future-access-list:{ token }");
             var bitmap = await _imagePipeline.FetchDecodedBitmapImageAsync(

--- a/ImagePipeline/ImagePipeline.Tests/Core/ImagePipelineTests.cs
+++ b/ImagePipeline/ImagePipeline.Tests/Core/ImagePipelineTests.cs
@@ -13,6 +13,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Windows.Graphics.Imaging;
 using Windows.Storage;
+using Windows.Storage.AccessCache;
 using Windows.UI.Xaml.Media.Imaging;
 
 namespace ImagePipeline.Tests.Core
@@ -30,11 +31,18 @@ namespace ImagePipeline.Tests.Core
         private readonly Uri IMAGE5_URL = new Uri("https://picsum.photos/800/600?image=5");
         private readonly Uri FAILURE_URL = new Uri("https://httpbin.org/image_not_found.png");
         private readonly Uri LOCAL_PNG_URL = new Uri("ms-appx:///Assets/pngs/1.png");
+        private readonly Uri LOCAL_PNG2_URL = new Uri("ms-appx:///Assets/pngs/2.png");
+        private readonly Uri LOCAL_PNG3_URL = new Uri("ms-appx:///Assets/pngs/3.png");
+        private readonly Uri LOCAL_PNG4_URL = new Uri("ms-appx:///Assets/pngs/4.png");
         private readonly Uri LOCAL_JPEG_URL = new Uri("ms-appx:///Assets/jpegs/1.jpeg");
         private readonly Uri LOCAL_GIF_URL = new Uri("ms-appx:///Assets/gifs/dog.gif");
         private readonly Uri LOCAL_APP_DATA_URL = new Uri("ms-appdata:///local/1.png");
+        private readonly Uri LOCAL_APP_DATA2_URL = new Uri("ms-appdata:///local/2.png");
         private readonly Uri ROAMING_APP_DATA_URL = new Uri("ms-appdata:///roaming/1.png");
+        private readonly Uri ROAMING_APP_DATA2_URL = new Uri("ms-appdata:///roaming/2.png");
         private readonly Uri TEMP_APP_DATA_URL = new Uri("ms-appdata:///temp/1.png");
+        private readonly Uri TEMP_APP_DATA2_URL = new Uri("ms-appdata:///temp/2.png");
+        private readonly string INVALID_TOKEN = "{11111111-1111-1111-1111-111111111111}";
 
         /// <copyright>
         /// beach.jpg file is from https://github.com/markevans/dragonfly
@@ -499,12 +507,13 @@ namespace ImagePipeline.Tests.Core
         {
             // Prepare resource for testing.
             var appData = ApplicationData.Current;
-            var sourceFile = await StorageFile.GetFileFromApplicationUriAsync(
-                new Uri("ms-appx:///Assets/pngs/2.png")).AsTask().ConfigureAwait(false);
+            var sourceFile = await StorageFile.GetFileFromApplicationUriAsync(LOCAL_PNG3_URL)
+                .AsTask()
+                .ConfigureAwait(false);
 
             await sourceFile.CopyAsync(appData.LocalFolder).AsTask().ConfigureAwait(false);
 
-            var fileUri = new Uri($"file:///{ appData.LocalFolder.Path }/2.png");
+            var fileUri = new Uri($"file:///{ appData.LocalFolder.Path }/3.png");
             var bitmap = await _imagePipeline.FetchDecodedBitmapImageAsync(
                 ImageRequest.FromUri(fileUri)).ConfigureAwait(false);
 
@@ -523,8 +532,9 @@ namespace ImagePipeline.Tests.Core
         {
             // Prepare resource for testing.
             var appData = ApplicationData.Current;
-            var sourceFile = await StorageFile.GetFileFromApplicationUriAsync(
-                new Uri("ms-appx:///Assets/pngs/1.png")).AsTask().ConfigureAwait(false);
+            var sourceFile = await StorageFile.GetFileFromApplicationUriAsync(LOCAL_PNG_URL)
+                .AsTask()
+                .ConfigureAwait(false);
 
             await sourceFile.CopyAsync(appData.LocalFolder).AsTask().ConfigureAwait(false);
 
@@ -546,8 +556,9 @@ namespace ImagePipeline.Tests.Core
         {
             // Prepare resource for testing.
             var appData = ApplicationData.Current;
-            var sourceFile = await StorageFile.GetFileFromApplicationUriAsync(
-                new Uri("ms-appx:///Assets/pngs/1.png")).AsTask().ConfigureAwait(false);
+            var sourceFile = await StorageFile.GetFileFromApplicationUriAsync(LOCAL_PNG_URL)
+                .AsTask()
+                .ConfigureAwait(false);
 
             await sourceFile.CopyAsync(appData.RoamingFolder).AsTask().ConfigureAwait(false);
 
@@ -569,8 +580,9 @@ namespace ImagePipeline.Tests.Core
         {
             // Prepare resource for testing.
             var appData = ApplicationData.Current;
-            var sourceFile = await StorageFile.GetFileFromApplicationUriAsync(
-                new Uri("ms-appx:///Assets/pngs/1.png")).AsTask().ConfigureAwait(false);
+            var sourceFile = await StorageFile.GetFileFromApplicationUriAsync(LOCAL_PNG_URL)
+                .AsTask()
+                .ConfigureAwait(false);
 
             await sourceFile.CopyAsync(appData.TemporaryFolder).AsTask().ConfigureAwait(false);
 
@@ -800,8 +812,9 @@ namespace ImagePipeline.Tests.Core
         {
             // Prepare resource for testing.
             var appData = ApplicationData.Current;
-            var sourceFile = await StorageFile.GetFileFromApplicationUriAsync(
-                new Uri("ms-appx:///Assets/pngs/4.png")).AsTask().ConfigureAwait(false);
+            var sourceFile = await StorageFile.GetFileFromApplicationUriAsync(LOCAL_PNG4_URL)
+                .AsTask()
+                .ConfigureAwait(false);
 
             await sourceFile.CopyAsync(appData.LocalFolder).AsTask().ConfigureAwait(false);
 
@@ -854,18 +867,19 @@ namespace ImagePipeline.Tests.Core
         /// Tests out fetching an encoded image from local app data folder
         /// </summary>
         [TestMethod]
-        public async Task TestFetchEncodedLocalAppData()
+        public async Task TestFetchEncodedImageLocalAppData()
         {
             // Prepare resource for testing.
             var appData = ApplicationData.Current;
-            var sourceFile = await StorageFile.GetFileFromApplicationUriAsync(
-                new Uri("ms-appx:///Assets/pngs/3.png")).AsTask().ConfigureAwait(false);
+            var sourceFile = await StorageFile.GetFileFromApplicationUriAsync(LOCAL_PNG2_URL)
+                .AsTask()
+                .ConfigureAwait(false);
 
             await sourceFile.CopyAsync(appData.LocalFolder).AsTask().ConfigureAwait(false);
 
             var completion = new ManualResetEvent(false);
             var dataSource = _imagePipeline.FetchEncodedImage(
-                ImageRequest.FromUri(LOCAL_APP_DATA_URL), null);
+                ImageRequest.FromUri(LOCAL_APP_DATA2_URL), null);
 
             var dataSubscriber = new BaseDataSubscriberImpl<CloseableReference<IPooledByteBuffer>>(
                 response =>
@@ -914,18 +928,19 @@ namespace ImagePipeline.Tests.Core
         /// Tests out fetching an encoded image from roaming app data folder
         /// </summary>
         [TestMethod]
-        public async Task TestFetchEncodedRoamingAppData()
+        public async Task TestFetchEncodedImageRoamingAppData()
         {
             // Prepare resource for testing.
             var appData = ApplicationData.Current;
-            var sourceFile = await StorageFile.GetFileFromApplicationUriAsync(
-                new Uri("ms-appx:///Assets/pngs/3.png")).AsTask().ConfigureAwait(false);
+            var sourceFile = await StorageFile.GetFileFromApplicationUriAsync(LOCAL_PNG2_URL)
+                .AsTask()
+                .ConfigureAwait(false);
 
             await sourceFile.CopyAsync(appData.RoamingFolder).AsTask().ConfigureAwait(false);
 
             var completion = new ManualResetEvent(false);
             var dataSource = _imagePipeline.FetchEncodedImage(
-                ImageRequest.FromUri(ROAMING_APP_DATA_URL), null);
+                ImageRequest.FromUri(ROAMING_APP_DATA2_URL), null);
 
             var dataSubscriber = new BaseDataSubscriberImpl<CloseableReference<IPooledByteBuffer>>(
                 response =>
@@ -974,12 +989,13 @@ namespace ImagePipeline.Tests.Core
         /// Tests out fetching an encoded image from temp app data folder
         /// </summary>
         [TestMethod]
-        public async Task TestFetchEncodedTempAppData()
+        public async Task TestFetchEncodedImageTempAppData()
         {
             // Prepare resource for testing.
             var appData = ApplicationData.Current;
-            var sourceFile = await StorageFile.GetFileFromApplicationUriAsync(
-                new Uri("ms-appx:///Assets/pngs/3.png")).AsTask().ConfigureAwait(false);
+            var sourceFile = await StorageFile.GetFileFromApplicationUriAsync(LOCAL_PNG2_URL)
+                .AsTask()
+                .ConfigureAwait(false);
 
             await sourceFile.CopyAsync(appData.TemporaryFolder).AsTask().ConfigureAwait(false);
 
@@ -1071,5 +1087,118 @@ namespace ImagePipeline.Tests.Core
         //        Assert.IsTrue(bitmap.PixelHeight == 91);
         //    });
         //}
+
+        /// <summary>
+        /// Tests out fetching an encoded image from future access list
+        /// </summary>
+        [TestMethod]
+        public async Task TestFetchEncodedImageFutureAccessList()
+        {
+            // Prepare resource for testing.
+            var fa = StorageApplicationPermissions.FutureAccessList;
+            var sourceFile = await StorageFile.GetFileFromApplicationUriAsync(LOCAL_PNG_URL)
+                .AsTask()
+                .ConfigureAwait(false);
+
+            string token = fa.Add(sourceFile, "test");
+
+            var completion = new ManualResetEvent(false);
+            var uri = new Uri($"urn:future-access-list:{ token }");
+            var dataSource = _imagePipeline.FetchEncodedImage(
+                ImageRequest.FromUri(uri), null);
+
+            var dataSubscriber = new BaseDataSubscriberImpl<CloseableReference<IPooledByteBuffer>>(
+                response =>
+                {
+                    CloseableReference<IPooledByteBuffer> reference = response.GetResult();
+                    if (reference != null)
+                    {
+                        IPooledByteBuffer inputStream = reference.Get();
+
+                        try
+                        {
+                            Assert.IsTrue(inputStream.Size != 0);
+                            Assert.IsTrue(_imagePipeline.IsInEncodedMemoryCache(uri));
+                        }
+                        catch (Exception)
+                        {
+                            Assert.Fail();
+                        }
+                        finally
+                        {
+                            CloseableReference<IPooledByteBuffer>.CloseSafely(reference);
+                            completion.Set();
+                        }
+
+                        return Task.CompletedTask;
+                    }
+                    else
+                    {
+                        Assert.Fail();
+                        completion.Set();
+                        return Task.CompletedTask;
+                    }
+                },
+                response =>
+                {
+                    Assert.Fail();
+                    completion.Set();
+                });
+
+            dataSource.Subscribe(dataSubscriber, CallerThreadExecutor.Instance);
+            completion.WaitOne();
+        }
+
+        /// <summary>
+        /// Tests out fetching an invalid encoded image from future access list
+        /// </summary>
+        [TestMethod]
+        public void TestFetchEncodedImageFutureAccessListFail()
+        {
+            var completion = new ManualResetEvent(false);
+            var uri = new Uri($"urn:future-access-list:{ INVALID_TOKEN }");
+            var dataSource = _imagePipeline.FetchEncodedImage(
+                ImageRequest.FromUri(uri), null);
+
+            var dataSubscriber = new BaseDataSubscriberImpl<CloseableReference<IPooledByteBuffer>>(
+                response =>
+                {
+                    Assert.Fail();
+                    completion.Set();
+                    return Task.CompletedTask;
+                },
+                response =>
+                {
+                    completion.Set();
+                });
+
+            dataSource.Subscribe(dataSubscriber, CallerThreadExecutor.Instance);
+            completion.WaitOne();
+        }
+
+        /// <summary>
+        /// Tests out fetching a decoded image from future access list
+        /// </summary>
+        [TestMethod]
+        public async Task TestFetchFutureAccessList()
+        {
+            // Prepare resource for testing.
+            var fa = StorageApplicationPermissions.FutureAccessList;
+            var sourceFile = await StorageFile.GetFileFromApplicationUriAsync(LOCAL_PNG_URL)
+                .AsTask()
+                .ConfigureAwait(false);
+
+            string token = fa.Add(sourceFile, "test");
+
+            var uri = new Uri($"urn:future-access-list:{ token }");
+            var bitmap = await _imagePipeline.FetchDecodedBitmapImageAsync(
+                ImageRequest.FromUri(uri)).ConfigureAwait(false);
+
+            await DispatcherHelpers.RunOnDispatcherAsync(() =>
+            {
+                Assert.IsTrue(bitmap.PixelWidth != 0);
+                Assert.IsTrue(bitmap.PixelHeight != 0);
+            });
+        }
     }
 }

--- a/ImagePipeline/ImagePipeline/Core/ProducerFactory.cs
+++ b/ImagePipeline/ImagePipeline/Core/ProducerFactory.cs
@@ -317,6 +317,16 @@ namespace ImagePipeline.Core
         }
 
         /// <summary>
+        /// Instantiates the <see cref="FutureAccessListFetchProducer"/>.
+        /// </summary>
+        public FutureAccessListFetchProducer NewFutureAccessListFetchProducer()
+        {
+            return new FutureAccessListFetchProducer(
+                _executorSupplier.ForLocalStorageRead,
+                _pooledByteBufferFactory);
+        }
+
+        /// <summary>
         /// Instantiates the <see cref="NetworkFetchProducer"/>.
         /// </summary>
         public NetworkFetchProducer NewNetworkFetchProducer(INetworkFetcher<FetchState> networkFetcher)

--- a/ImagePipeline/ImagePipeline/ImagePipeline.csproj
+++ b/ImagePipeline/ImagePipeline/ImagePipeline.csproj
@@ -203,6 +203,7 @@
     <Compile Include="Producers\LocalExifThumbnailProducer.cs" />
     <Compile Include="Producers\LocalFetchProducer.cs" />
     <Compile Include="Producers\LocalFileFetchProducer.cs" />
+    <Compile Include="Producers\FutureAccessListFetchProducer.cs" />
     <Compile Include="Producers\LocalResourceFetchProducer.cs" />
     <Compile Include="Producers\LocalVideoThumbnailProducer.cs" />
     <Compile Include="Producers\MultiplexProducer.cs" />

--- a/ImagePipeline/ImagePipeline/Producers/FutureAccessListFetchProducer.cs
+++ b/ImagePipeline/ImagePipeline/Producers/FutureAccessListFetchProducer.cs
@@ -4,6 +4,7 @@ using ImagePipeline.Memory;
 using ImagePipeline.Request;
 using System;
 using System.IO;
+using System.Net;
 using System.Threading.Tasks;
 using Windows.Storage.AccessCache;
 
@@ -32,9 +33,10 @@ namespace ImagePipeline.Producers
         /// </summary>
         protected override Task<EncodedImage> GetEncodedImage(ImageRequest imageRequest)
         {
-            string originalString = imageRequest.SourceUri.OriginalString;
+            string originalString = WebUtility.UrlDecode(imageRequest.SourceUri.OriginalString);
             string token = originalString.Substring(originalString.LastIndexOf(":") + 1);
-            return StorageApplicationPermissions.FutureAccessList.GetFileAsync(token).AsTask()
+            return StorageApplicationPermissions.FutureAccessList.GetFileAsync(token)
+                .AsTask()
                 .ContinueWith(
                 (filePathTask) =>
                 {

--- a/ImagePipeline/ImagePipeline/Producers/FutureAccessListFetchProducer.cs
+++ b/ImagePipeline/ImagePipeline/Producers/FutureAccessListFetchProducer.cs
@@ -1,0 +1,63 @@
+﻿using FBCore.Concurrency;
+using ImagePipeline.Image;
+using ImagePipeline.Memory;
+using ImagePipeline.Request;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Windows.Storage.AccessCache;
+
+namespace ImagePipeline.Producers
+{
+    /// <summary>
+    /// Represents a future-access list fetch producer.
+    /// </summary>
+    public class FutureAccessListFetchProducer : LocalFetchProducer
+    {
+        internal const string PRODUCER_NAME = "FutureAccessListFetchProducer";
+
+        /// <summary>
+        /// Instantiates the <see cref="FutureAccessListFetchProducer"/>.
+        /// </summary>
+        public FutureAccessListFetchProducer(
+            IExecutorService executor,
+            IPooledByteBufferFactory pooledByteBufferFactory) : base(
+                executor,
+                pooledByteBufferFactory)
+        {
+        }
+
+        /// <summary>
+        /// Gets the encoded image.
+        /// </summary>
+        protected override Task<EncodedImage> GetEncodedImage(ImageRequest imageRequest)
+        {
+            string originalString = imageRequest.SourceUri.OriginalString;
+            string token = originalString.Substring(originalString.LastIndexOf(":") + 1);
+            return StorageApplicationPermissions.FutureAccessList.GetFileAsync(token).AsTask()
+                .ContinueWith(
+                (filePathTask) =>
+                {
+                    return filePathTask.Result.OpenStreamForReadAsync();
+                })
+                .Unwrap()
+                .ContinueWith(
+                (fileReadTask) =>
+                {
+                    var stream = fileReadTask.Result;
+                    return GetEncodedImage(stream, (int)(stream.Length));
+                });
+        }
+
+        /// <summary>
+        /// The name of the Producer.
+        /// </summary>
+        protected override string ProducerName
+        {
+            get
+            {
+                return PRODUCER_NAME;
+            }
+        }
+    }
+}

--- a/ImagePipeline/ImagePipeline/Producers/LocalFileFetchProducer.cs
+++ b/ImagePipeline/ImagePipeline/Producers/LocalFileFetchProducer.cs
@@ -44,9 +44,9 @@ namespace ImagePipeline.Producers
                     imageRequest.SourceUri).AsTask();
 
                 return uriToFilePathTask.ContinueWith(
-                    (filepathTask) =>
+                    (filePathTask) =>
                     {
-                        FileInfo file = new FileInfo(filepathTask.Result.Path);
+                        FileInfo file = new FileInfo(filePathTask.Result.Path);
                         return GetEncodedImage(file.OpenRead(), (int)(file.Length));
                     });
             }


### PR DESCRIPTION
This PR handles a special urn for [FutureAccessList](https://docs.microsoft.com/en-us/uwp/api/windows.storage.accesscache.storageapplicationpermissions#Windows_Storage_AccessCache_StorageApplicationPermissions_FutureAccessList).
Uri format: 

> urn:future-access-list:{GUID}