### PR TITLE
Adds helper method to retrieve file cache path.

### DIFF
--- a/ImagePipeline/ImagePipeline.Tests/Core/ImagePipelineTests.cs
+++ b/ImagePipeline/ImagePipeline.Tests/Core/ImagePipelineTests.cs
@@ -1227,5 +1227,32 @@ namespace ImagePipeline.Tests.Core
                 Assert.IsTrue(bitmap.PixelHeight != 0);
             });
         }
+
+        /// <summary>
+        /// Tests out getting the file cache path when the file has been
+        /// written to disk successfully.
+        /// </summary>
+        [TestMethod, Timeout(5000)]
+        public async Task TestGetFileCachePathSuccess()
+        {
+            await _imagePipeline.PrefetchToDiskCacheAsync(IMAGE_URL).ConfigureAwait(false);
+            Assert.IsTrue(await _imagePipeline.IsInDiskCacheAsync(IMAGE_URL).ConfigureAwait(false));
+
+            FileInfo info = await _imagePipeline.GetFileCachePath(IMAGE_URL).ConfigureAwait(false);
+            Assert.IsNotNull(info);
+        }
+
+        /// <summary>
+        /// Tests out getting the file cache path when the file doesn't exist.
+        /// </summary>
+        [TestMethod, Timeout(5000)]
+        public async Task TestGetFileCachePathFail()
+        {
+            await _imagePipeline.PrefetchToDiskCacheAsync(IMAGE_URL).ConfigureAwait(false);
+            Assert.IsTrue(await _imagePipeline.IsInDiskCacheAsync(IMAGE_URL).ConfigureAwait(false));
+
+            FileInfo info = await _imagePipeline.GetFileCachePath(FAILURE_URL).ConfigureAwait(false);
+            Assert.IsNull(info);
+        }
     }
 }

--- a/ImagePipeline/ImagePipeline/Cache/BufferedDiskCache.cs
+++ b/ImagePipeline/ImagePipeline/Cache/BufferedDiskCache.cs
@@ -329,6 +329,7 @@ namespace ImagePipeline.Cache
                 {
                     _stagingArea.ClearAll();
                     _fileCache.ClearAll();
+                    _writeToDiskCacheTasks.Clear();
                 });
             }
             catch (Exception)

--- a/ImagePipeline/ImagePipeline/Cache/BufferedDiskCache.cs
+++ b/ImagePipeline/ImagePipeline/Cache/BufferedDiskCache.cs
@@ -261,6 +261,10 @@ namespace ImagePipeline.Cache
                     {
                         _stagingArea.Remove(key, finalEncodedImage);
                         EncodedImage.CloseSafely(finalEncodedImage);
+
+                        // Removes write task after it's completed.
+                        Task writeTaskCompleted = default(Task);
+                        _writeToDiskCacheTasks.TryRemove(key, out writeTaskCompleted);
                     }
                 });
 
@@ -274,6 +278,10 @@ namespace ImagePipeline.Cache
                 Debug.WriteLine($"Failed to schedule disk-cache write for { key.ToString() }");
                 _stagingArea.Remove(key, encodedImage);
                 EncodedImage.CloseSafely(finalEncodedImage);
+
+                // Removes write task due to error.
+                Task writeTaskCompleted = default(Task);
+                _writeToDiskCacheTasks.TryRemove(key, out writeTaskCompleted);
                 throw;
             }
         }

--- a/ImagePipeline/ImagePipeline/Core/ImagePipelineCore.cs
+++ b/ImagePipeline/ImagePipeline/Core/ImagePipelineCore.cs
@@ -754,7 +754,21 @@ namespace ImagePipeline.Core
             }
             else
             {
-                return Task.FromResult(default(FileInfo));
+                return _mainBufferedDiskCache.Contains(cacheKey).ContinueWith(
+                    task =>
+                    {
+                        bool fileExists = task.Result;
+                        if (fileExists)
+                        {
+                            IBinaryResource resource = ImagePipelineFactory.Instance.GetMainDiskStorageCache().GetResource(cacheKey);
+                            return ((FileBinaryResource)resource).File;
+                        }
+                        else
+                        {
+                            return default(FileInfo);
+                        }
+                    },
+                    TaskContinuationOptions.ExecuteSynchronously);
             }
         }
 

--- a/ImagePipeline/ImagePipeline/Core/ImagePipelineCore.cs
+++ b/ImagePipeline/ImagePipeline/Core/ImagePipelineCore.cs
@@ -1,4 +1,5 @@
-﻿using Cache.Common;
+﻿using BinaryResource;
+using Cache.Common;
 using FBCore.Common.Internal;
 using FBCore.Common.References;
 using FBCore.Common.Util;
@@ -729,6 +730,32 @@ namespace ImagePipeline.Core
             });
 
             return taskCompletionSource.Task;
+        }
+
+        /// <summary>
+        /// Gets the file cache path.
+        /// </summary>
+        /// <param name="uri">The image uri.</param>
+        public Task<FileInfo> GetFileCachePath(Uri uri)
+        {
+            ICacheKey cacheKey = _cacheKeyFactory.GetEncodedCacheKey(
+                ImageRequest.FromUri(uri), null);
+
+            Task writeTask = _mainBufferedDiskCache.GetWriteToDiskCacheTask(cacheKey);
+            if (writeTask != default(Task))
+            {
+                return writeTask.ContinueWith(
+                    task =>
+                    {
+                        IBinaryResource resource = ImagePipelineFactory.Instance.GetMainDiskStorageCache().GetResource(cacheKey);
+                        return ((FileBinaryResource)resource).File;
+                    },
+                    TaskContinuationOptions.ExecuteSynchronously);
+            }
+            else
+            {
+                return Task.FromResult(default(FileInfo));
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
By design, when we call *PrefetchToDiskCacheAsync* method, the image is downloaded and written to the staging area (in memory) and then a background task is initialized to actually writes the file to disk. *GetFileCachePath* method was added to allow waiting for the file creation and returns its local path.